### PR TITLE
header-profile.png 404 fix

### DIFF
--- a/css/portal.css
+++ b/css/portal.css
@@ -6882,7 +6882,7 @@ h3, h4, h5 {
 
 .nav-header {
   padding: 33px 25px;
-  background: url("/patterns/header-profile.png") no-repeat; }
+  background: url("patterns/header-profile.png") no-repeat; }
 
 .pace-done .nav-header {
   transition-duration: 0.5s; }


### PR DESCRIPTION
header-profile.png was being referenced with / instead of relatively causing a 404 error after login. This commit fixes the reference. 
